### PR TITLE
Fix pg11 make error

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -59,3 +59,11 @@ Datum fio_readdir(PG_FUNCTION_ARGS);
 Datum fio_mkdir(PG_FUNCTION_ARGS);
 Datum fio_chmod(PG_FUNCTION_ARGS);
 #endif
+
+#ifndef FALSE
+#define FALSE   (0)
+#endif
+
+#ifndef TRUE
+#define TRUE    (!FALSE)
+#endif


### PR DESCRIPTION
Hello!

When trying to do `make` on pg11 I get the error:
```
mkdir.c: In function ‘fio_mkdir’:
mkdir.c:42:22: error: ‘FALSE’ undeclared (first use in this function)
   42 |     bool recursive = FALSE;
      |                      ^~~~~
mkdir.c:42:22: note: each undeclared identifier is reported only once for each function it appears in
make: *** [<builtin>: mkdir.o] Error 1
```
The fix is pretty much the same as https://github.com/postgrespro/imgsmlr/issues/8.

**Edit**: Just noted this should fix #8.