### PR TITLE
fix: Add 'extern PGDLLEXPORT' keywords to load in pg16.

### DIFF
--- a/src/fio.h
+++ b/src/fio.h
@@ -54,13 +54,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
-Datum fio_writefile(PG_FUNCTION_ARGS);
-Datum fio_readfile(PG_FUNCTION_ARGS);
-Datum fio_readdir(PG_FUNCTION_ARGS);
-Datum fio_mkdir(PG_FUNCTION_ARGS);
-Datum fio_chmod(PG_FUNCTION_ARGS);
-Datum fio_removefile(PG_FUNCTION_ARGS);
-Datum fio_renamefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_writefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_readfile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_readdir(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_mkdir(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_chmod(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_removefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_renamefile(PG_FUNCTION_ARGS);
 #endif
 
 #ifndef FALSE


### PR DESCRIPTION
Investigating on postgres 16 extension loading problem, I have found a reference in a commit from Tom Lane: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=e04a8059a74c125a8af94acdcb7b15b92188470a

To not break the original design pattern code, I prefer to add "extern PGDLLEXPORT" keyword on function inclusion part.

Fix #18 and #17 issues.

Already tested with all supported versions of postgresql.