### PR TITLE
fix: Add 'extern PGDLLEXPORT' for loading on pg16.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 MODULE_big = fio
 
 OBJS = src/fio.o       \
+       src/renamefile.o \
+       src/removefile.o \
+       src/writefile.o \
+       src/readfile.o  \
+       src/readdir.o   \
+       src/mkdir.o     \
+       src/chmod.o     \
        src/utils.o
 
 EXTENSION = fio

--- a/src/chmod.c
+++ b/src/chmod.c
@@ -29,23 +29,34 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fio.h"
 
-PG_MODULE_MAGIC;
+Datum fio_chmod(PG_FUNCTION_ARGS) {
+    // chmod(pathname varchar, mode varchar);
 
-void _PG_init(void);
-void _PG_fini(void);
-
-void _PG_init(void)
-{
+    text *v_pathname;
+    char *pathname;
+    text *vmode;
+    size_t mode_ch_size;
+    char *ch_mode;
+    char *ch_mode_copy;
+    int mode;
+    if (PG_ARGISNULL(0)) {
+        elog(ERROR, "path must be specified");
+        return 0;
+    }
+    v_pathname = PG_GETARG_TEXT_P(0);
+    pathname = text_to_cstring(v_pathname);
+    if (PG_ARGISNULL(1)) {
+        elog(ERROR, "mode must be specified");
+        return 0;
+    }
+    vmode = PG_GETARG_TEXT_P(1);
+    mode_ch_size = VARSIZE(vmode) - VARHDRSZ;
+    ch_mode = text_to_cstring(vmode);
+    ch_mode_copy = text_to_cstring(PG_GETARG_TEXT_P(1));
+    mode = (int) strtol(ch_mode, &ch_mode_copy, 8);
+    if (strncmp(ch_mode, ch_mode_copy, mode_ch_size) == 0) {
+        elog(ERROR, "mode must be specified");
+        return 0;
+    }
+    return chmod(pathname, mode);
 }
-
-void _PG_fini(void)
-{
-}
-
-PG_FUNCTION_INFO_V1(fio_removefile);
-PG_FUNCTION_INFO_V1(fio_renamefile);
-PG_FUNCTION_INFO_V1(fio_writefile);
-PG_FUNCTION_INFO_V1(fio_readfile);
-PG_FUNCTION_INFO_V1(fio_readdir);
-PG_FUNCTION_INFO_V1(fio_mkdir);
-PG_FUNCTION_INFO_V1(fio_chmod);

--- a/src/fio.h
+++ b/src/fio.h
@@ -54,13 +54,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "utils.h"
 
+extern PGDLLEXPORT Datum fio_writefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_readfile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_readdir(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_mkdir(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_chmod(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_removefile(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum fio_renamefile(PG_FUNCTION_ARGS);
 #endif
-
-#define BUFFER_SIZE 1024
-
-struct dircontext {
-    DIR *dir;
-};
 
 #ifndef FALSE
 #define FALSE   (0)

--- a/src/mkdir.c
+++ b/src/mkdir.c
@@ -29,23 +29,48 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fio.h"
 
-PG_MODULE_MAGIC;
+Datum fio_mkdir(PG_FUNCTION_ARGS) {
+    // mkdir(pathname varchar, mode varchar, recursive boolean default false);
 
-void _PG_init(void);
-void _PG_fini(void);
-
-void _PG_init(void)
-{
+    text *v_pathname;
+    char *pathname;
+    text *vmode;
+    size_t mode_ch_size;
+    char *ch_mode;
+    char *ch_mode_copy;
+    int mode;
+    bool recursive = FALSE;
+    if (PG_ARGISNULL(0)) {
+        elog(ERROR, "path must be specified");
+        return 0;
+    }
+    v_pathname = PG_GETARG_TEXT_P(0);
+    pathname = text_to_cstring(v_pathname);
+    if (strlen(pathname) == 0) {
+        elog(ERROR, "path must be specified");
+        return 0;
+    }
+    if (PG_ARGISNULL(1)) {
+        elog(ERROR, "mode must be specified");
+        return 0;
+    }
+    vmode = PG_GETARG_TEXT_P(1);
+    mode_ch_size = VARSIZE(vmode) - VARHDRSZ;
+    ch_mode = text_to_cstring(vmode);
+    ch_mode_copy= text_to_cstring(PG_GETARG_TEXT_P(1));
+    mode = (int) strtol(ch_mode, &ch_mode_copy, 8);
+    if (strncmp(ch_mode, ch_mode_copy, mode_ch_size) == 0) {
+        elog(ERROR, "mode must be specified");
+        return 0;
+    }
+    if (!PG_ARGISNULL(2)) {
+        recursive = PG_GETARG_BOOL(2);
+    }
+    if (recursive) {
+        mkdir_recursive(pathname, mode);
+    } else {
+        mkdir(pathname, mode);
+        chmod(pathname, mode);
+    }
+    return 0;
 }
-
-void _PG_fini(void)
-{
-}
-
-PG_FUNCTION_INFO_V1(fio_removefile);
-PG_FUNCTION_INFO_V1(fio_renamefile);
-PG_FUNCTION_INFO_V1(fio_writefile);
-PG_FUNCTION_INFO_V1(fio_readfile);
-PG_FUNCTION_INFO_V1(fio_readdir);
-PG_FUNCTION_INFO_V1(fio_mkdir);
-PG_FUNCTION_INFO_V1(fio_chmod);

--- a/src/readdir.c
+++ b/src/readdir.c
@@ -1,0 +1,92 @@
+/**
+Copyright (c) 2015, Cafer Şimşek
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the name of pgsql-fio nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "fio.h"
+
+struct dircontext {
+    DIR *dir;
+};
+
+Datum fio_readdir(PG_FUNCTION_ARGS) {
+    // readdir(pathname varchar, pattern varchar default '*');
+
+    FuncCallContext *funcctx;
+    DIR *dir = NULL;
+    char *pathname;
+    char *pattern;
+    struct dirent *dp;
+    struct dircontext *dirctx;
+    if (PG_ARGISNULL(0)) {
+        elog(ERROR, "path must be specified");
+    }
+    if (PG_ARGISNULL(1)) {
+        elog(ERROR, "pattern must be specified");
+    }
+    pathname = text_to_cstring(PG_GETARG_TEXT_P(0));
+    pattern = text_to_cstring(PG_GETARG_TEXT_P(1));
+    if (SRF_IS_FIRSTCALL()) {
+        MemoryContext oldcontext;
+        TupleDesc tupdesc;
+        funcctx = SRF_FIRSTCALL_INIT();
+        oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+        if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+            ereport(ERROR,
+                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                     errmsg("function returning record called in context "
+                            "that cannot accept type record")));
+        funcctx->attinmeta = TupleDescGetAttInMetadata(tupdesc);
+        dir = opendir(pathname);
+        if (dir == NULL) {
+            int err = errno;
+            elog(ERROR, "cannot open dir: %s (%s)", pathname, strerror(err));
+        }
+        dirctx = (struct dircontext *) palloc(sizeof(struct dircontext *));
+        dirctx->dir = dir;
+        funcctx->user_fctx = (void *) dirctx;
+        MemoryContextSwitchTo(oldcontext);
+    }
+    funcctx = SRF_PERCALL_SETUP();
+    dirctx = (struct dircontext *) funcctx->user_fctx;
+    dir = dirctx->dir;
+    while ((dp = readdir(dir)) != NULL) {
+        if (fnmatch(pattern, dp->d_name, FNM_NOESCAPE) == 0) {
+            HeapTuple tuple;
+            Datum result;
+            char *value = (char *) palloc(dp->d_reclen * sizeof(char));
+            memcpy(value, dp->d_name, dp->d_reclen);
+            tuple = BuildTupleFromCStrings(funcctx->attinmeta, &value);
+            result = HeapTupleGetDatum(tuple);
+            pfree(value);
+            SRF_RETURN_NEXT(funcctx, result);
+        }
+    }
+    closedir(dir);
+    pfree(dirctx);
+    SRF_RETURN_DONE(funcctx);
+}

--- a/src/removefile.c
+++ b/src/removefile.c
@@ -29,23 +29,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fio.h"
 
-PG_MODULE_MAGIC;
+Datum fio_removefile(PG_FUNCTION_ARGS) {
+    text *vfilename;
+    char *filename;
 
-void _PG_init(void);
-void _PG_fini(void);
+    if (PG_ARGISNULL(0)) {
+        elog(ERROR, "filename must be specified");
+        return 0;
+    }
+    vfilename = PG_GETARG_TEXT_P(0);
 
-void _PG_init(void)
-{
+    filename = text_to_cstring(vfilename);
+
+    if (remove(filename) != 0) {
+        int err = errno;
+        elog(ERROR, "cannot remove file: %s (%s)", filename, strerror(err));
+        return 0;
+    }
+    pfree(filename);
+    PG_RETURN_NULL();
 }
-
-void _PG_fini(void)
-{
-}
-
-PG_FUNCTION_INFO_V1(fio_removefile);
-PG_FUNCTION_INFO_V1(fio_renamefile);
-PG_FUNCTION_INFO_V1(fio_writefile);
-PG_FUNCTION_INFO_V1(fio_readfile);
-PG_FUNCTION_INFO_V1(fio_readdir);
-PG_FUNCTION_INFO_V1(fio_mkdir);
-PG_FUNCTION_INFO_V1(fio_chmod);


### PR DESCRIPTION
I closed pull request #19 and open this with all necessary files.

For completeness I report the #19 pr text:

> Investigating on postgres 16 extension loading problem, I have found a reference in a commit from Tom Lane: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=e04a8059a74c125a8af94acdcb7b15b92188470a
>
>To not break the original design pattern code, I prefer to add "extern PGDLLEXPORT" keyword on function inclusion part.
>
>Fix https://github.com/csimsek/pgsql-fio/issues/18 and https://github.com/csimsek/pgsql-fio/pull/17 issues.
>
>Already tested with all supported versions of postgresql.

@csimsek, you should be able to merge now.

Thanks,
Matteo